### PR TITLE
Update react-scripts to avoid Babel Loader error

### DIFF
--- a/a11y-app/package.json
+++ b/a11y-app/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^12.8.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
+    "react-scripts": "5.0.0",
     "web-vitals": "^1.1.2"
   },
   "scripts": {


### PR DESCRIPTION
`react-scripts` was including `babel-loader 8.1.0`, conflicting with one of the other packages.  Following the directions to resolve didn't help, but updating the version did.